### PR TITLE
feat: add integration tests with gemini-1.5-flash and improve README

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,53 @@
+name: Integration Tests
+
+on:
+  # Manual trigger
+  workflow_dispatch:
+  # Run on PR to main, but only if integration tests are explicitly requested
+  pull_request:
+    branches: [ main, master ]
+    types: [ labeled ]
+
+jobs:
+  integration-tests:
+    # Only run if manually triggered or if PR has 'run-integration-tests' label
+    if: |
+      github.event_name == 'workflow_dispatch' || 
+      (github.event_name == 'pull_request' && contains(github.event.label.name, 'run-integration-tests'))
+    
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[dev]"
+    
+    - name: Run integration tests
+      env:
+        GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # Run only integration tests with verbose output
+        pytest -v -m integration --tb=short
+    
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: integration-test-results-${{ matrix.python-version }}
+        path: |
+          .pytest_cache/
+          htmlcov/
+        retention-days: 7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,3 +105,8 @@ python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 asyncio_default_fixture_loop_scope = "function"
+markers = [
+    "integration: marks tests as integration tests that use real APIs (deselect with '-m \"not integration\"')",
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
+addopts = "-m 'not integration'"  # By default, skip integration tests

--- a/src/cli_main.py
+++ b/src/cli_main.py
@@ -352,11 +352,7 @@ def validate_cli_arguments(args: Any):
             "--context-only to generate raw context without AI review."
         )
 
-    # Validate project path
-    if args.project_path is None:
-        raise ValueError(
-            "project_path is required. Please specify a path to your project directory."
-        )
+    # Project path is optional - defaults to current directory in generate_code_review_context_main
 
     # Validate temperature range
     if args.temperature < 0.0 or args.temperature > 2.0:
@@ -652,7 +648,9 @@ Working examples:
 
                 # Execute auto-prompt workflow
                 # Convert project path to absolute path for meta prompt analyzer
-                absolute_project_path = os.path.abspath(args.project_path)
+                # Use current directory if not specified
+                project_path = args.project_path or os.getcwd()
+                absolute_project_path = os.path.abspath(project_path)
                 result = execute_auto_prompt_workflow(
                     project_path=absolute_project_path,
                     scope=args.scope,

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,75 @@
+# Integration Tests
+
+This directory contains integration tests that make real API calls to Google's Gemini API.
+
+## Overview
+
+These tests use `gemini-1.5-flash` for cost-effective validation of core functionality with actual API responses.
+
+## Requirements
+
+- **API Key**: Set `GEMINI_API_KEY` environment variable
+- **Optional**: Set `GITHUB_TOKEN` for GitHub integration tests
+
+## Running Tests
+
+```bash
+# Set up API key
+export GEMINI_API_KEY=your_key_here
+
+# Run all integration tests
+pytest -m integration
+
+# Run with verbose output
+pytest -v -m integration
+
+# Run specific test class
+pytest tests/integration/test_gemini_real.py::TestGeminiRealAPI
+
+# Run with timeout enforcement
+pytest -m integration --timeout=60
+```
+
+## Test Coverage
+
+### What We Test
+- ✅ Basic code review generation
+- ✅ Temperature parameter effects
+- ✅ Model configuration validation
+- ✅ Error handling with invalid inputs
+- ✅ Context generation workflows
+- ✅ Meta prompt generation
+
+### What We Don't Test
+- ❌ Thinking mode (not supported by gemini-1.5-flash)
+- ❌ URL context features (not supported by gemini-1.5-flash)
+- ❌ Advanced model features requiring 2.0+ models
+
+## Cost Considerations
+
+- Tests use small contexts to minimize API usage
+- Each test run costs approximately $0.01-0.05
+- Tests are excluded from default test runs
+- CI/CD runs only on manual trigger or explicit label
+
+## Writing New Integration Tests
+
+1. Always use the `integration_test_model` fixture (returns `gemini-1.5-flash`)
+2. Keep contexts small (use `small_test_context` fixture when possible)
+3. Use fuzzy assertions for API responses (content varies between runs)
+4. Mark tests with `@pytest.mark.integration`
+5. Skip tests requiring features not supported by gemini-1.5-flash
+
+Example:
+```python
+@pytest.mark.integration
+def test_my_feature(integration_test_model, small_test_context):
+    result = send_to_gemini_for_review(
+        context_content=small_test_context,
+        model=integration_test_model,
+        temperature=0.5,
+        return_text=True,
+    )
+    assert result is not None
+    assert len(result) > 50
+```

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,111 @@
+"""
+Configuration for integration tests that use real Gemini API.
+
+These tests make actual API calls to gemini-1.5-flash for cost-effective testing.
+Run with: pytest -m integration
+"""
+
+import os
+import pytest
+import sys
+from pathlib import Path
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+
+@pytest.fixture(scope="session", autouse=True)
+def validate_api_key():
+    """Validate that GEMINI_API_KEY is available for integration tests."""
+    api_key = os.getenv("GEMINI_API_KEY")
+    if not api_key:
+        pytest.skip(
+            "Integration tests require GEMINI_API_KEY environment variable. "
+            "Set it to run real API tests: export GEMINI_API_KEY=your_key_here"
+        )
+
+
+@pytest.fixture
+def integration_test_model():
+    """Return the model to use for integration tests."""
+    # Use gemini-1.5-flash for cost-effective testing
+    return "gemini-1.5-flash"
+
+
+@pytest.fixture
+def small_test_context():
+    """Provide a small context for testing to minimize API costs."""
+    return """# Code Review Context
+
+## Project Overview
+This is a test project for integration testing.
+
+## Recent Changes
+- Added new function `calculate_sum(a, b)` that returns a + b
+- Fixed bug in error handling
+
+## Code Sample
+```python
+def calculate_sum(a: int, b: int) -> int:
+    \"\"\"Add two numbers together.\"\"\"
+    return a + b
+```
+
+Please review this code for best practices and potential improvements.
+"""
+
+
+@pytest.fixture
+def minimal_project_dir(tmp_path):
+    """Create a minimal project structure for testing."""
+    # Create basic structure
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "__init__.py").write_text("")
+    (tmp_path / "src" / "main.py").write_text("""
+def hello_world():
+    \"\"\"Simple hello world function.\"\"\"
+    print("Hello, World!")
+
+def add_numbers(a, b):
+    \"\"\"Add two numbers.\"\"\"
+    return a + b
+""")
+    
+    # Create a simple task list
+    (tmp_path / "tasks").mkdir()
+    (tmp_path / "tasks" / "tasks-test.md").write_text("""
+## Tasks
+
+- [x] 1.0 Create basic functions
+  - [x] 1.1 Implement hello_world
+  - [x] 1.2 Implement add_numbers
+- [ ] 2.0 Add tests
+  - [ ] 2.1 Test hello_world
+  - [ ] 2.2 Test add_numbers
+""")
+    
+    return tmp_path
+
+
+@pytest.fixture
+def integration_timeout():
+    """Timeout for integration tests (in seconds)."""
+    return 30  # 30 seconds should be enough for gemini-1.5-flash
+
+
+# Mark all tests in this directory as integration tests
+pytest_plugins = []
+
+
+def pytest_configure(config):
+    """Register custom markers."""
+    config.addinivalue_line(
+        "markers", "integration: mark test as an integration test that uses real APIs"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    """Automatically mark all tests in integration directory."""
+    for item in items:
+        if "integration" in str(item.fspath):
+            item.add_marker(pytest.mark.integration)

--- a/tests/integration/test_gemini_real.py
+++ b/tests/integration/test_gemini_real.py
@@ -1,0 +1,207 @@
+"""
+Integration tests that make real API calls to gemini-1.5-flash.
+
+These tests validate core functionality with actual Gemini API responses.
+Only tests features supported by gemini-1.5-flash (no thinking mode or URL context).
+"""
+
+import os
+import pytest
+from typing import Optional
+
+from src.gemini_api_client import send_to_gemini_for_review, GEMINI_AVAILABLE
+from src.model_config_manager import load_model_config
+
+
+@pytest.mark.integration
+class TestGeminiRealAPI:
+    """Test suite for real Gemini API integration."""
+    
+    def test_gemini_api_available(self):
+        """Test that Gemini API is available and configured."""
+        assert GEMINI_AVAILABLE, "Gemini API library not available"
+        assert os.getenv("GEMINI_API_KEY"), "GEMINI_API_KEY not set"
+    
+    def test_basic_code_review_generation(self, small_test_context, integration_test_model, integration_timeout):
+        """Test basic code review generation with real API."""
+        result = send_to_gemini_for_review(
+            context_content=small_test_context,
+            project_path=None,
+            temperature=0.5,
+            model=integration_test_model,
+            return_text=True,
+            include_formatting=False,
+            thinking_budget=None,  # Not supported by gemini-1.5-flash
+        )
+        
+        assert result is not None, "API should return a response"
+        assert isinstance(result, str), "Response should be a string"
+        assert len(result) > 50, "Response should have meaningful content"
+        
+        # Check for code review elements (fuzzy matching for API variability)
+        result_lower = result.lower()
+        assert any(keyword in result_lower for keyword in ["code", "function", "review", "improve", "suggest"])
+    
+    def test_temperature_variation(self, small_test_context, integration_test_model):
+        """Test that different temperatures produce different outputs."""
+        # Get low temperature response (more deterministic)
+        result_low = send_to_gemini_for_review(
+            context_content=small_test_context,
+            project_path=None,
+            temperature=0.1,
+            model=integration_test_model,
+            return_text=True,
+            include_formatting=False,
+        )
+        
+        # Get high temperature response (more creative)
+        result_high = send_to_gemini_for_review(
+            context_content=small_test_context,
+            project_path=None,
+            temperature=0.9,
+            model=integration_test_model,
+            return_text=True,
+            include_formatting=False,
+        )
+        
+        assert result_low is not None
+        assert result_high is not None
+        # We can't guarantee they're different due to model behavior,
+        # but both should be valid responses
+        assert len(result_low) > 50
+        assert len(result_high) > 50
+    
+    def test_model_config_compatibility(self, integration_test_model):
+        """Test that gemini-1.5-flash is properly configured."""
+        config = load_model_config()
+        
+        # Check model capabilities for gemini-1.5-flash
+        url_supported = integration_test_model in config["model_capabilities"]["url_context_supported"]
+        thinking_supported = integration_test_model in config["model_capabilities"]["thinking_mode_supported"]
+        
+        # gemini-1.5-flash should NOT support these advanced features
+        assert not url_supported, "gemini-1.5-flash should not support URL context"
+        assert not thinking_supported, "gemini-1.5-flash should not support thinking mode"
+    
+    def test_error_handling_invalid_content(self, integration_test_model):
+        """Test API error handling with invalid content."""
+        # Test with empty content
+        result = send_to_gemini_for_review(
+            context_content="",
+            project_path=None,
+            temperature=0.5,
+            model=integration_test_model,
+            return_text=True,
+        )
+        
+        # Should handle gracefully (might return None or error message)
+        # The exact behavior depends on API implementation
+        assert result is None or isinstance(result, str)
+
+
+@pytest.mark.integration
+class TestContextGeneration:
+    """Test context generation with real API responses."""
+    
+    def test_generate_code_review_context_real(self, minimal_project_dir):
+        """Test full context generation flow with real project."""
+        from src.generate_code_review_context import generate_code_review_context_main
+        
+        # Generate context (doesn't use API, but prepares for it)
+        context = generate_code_review_context_main(
+            project_path=str(minimal_project_dir),
+            scope="full_project",
+            enable_gemini_review=False,  # Just generate context, don't review
+            include_claude_memory=False,
+            include_cursor_rules=False,
+            raw_context_only=True,
+            text_output=True,
+        )
+        
+        assert context is not None
+        assert isinstance(context, str)
+        assert "# Code Review Context" in context
+        assert "main.py" in context  # Should include our test file
+    
+    def test_meta_prompt_generation_real(self, minimal_project_dir, integration_test_model):
+        """Test meta prompt generation with real API."""
+        from src.meta_prompt_generator import generate_meta_prompt
+        
+        # First generate context
+        from src.generate_code_review_context import generate_code_review_context_main
+        
+        context = generate_code_review_context_main(
+            project_path=str(minimal_project_dir),
+            scope="full_project",
+            enable_gemini_review=False,
+            include_claude_memory=False,
+            include_cursor_rules=False,
+            raw_context_only=True,
+            text_output=True,
+        )
+        
+        # Generate meta prompt with real API
+        meta_prompt = generate_meta_prompt(
+            context_content=context,
+            project_path=str(minimal_project_dir),
+            model=integration_test_model,
+            temperature=0.5,
+            text_output=True,
+        )
+        
+        assert meta_prompt is not None
+        assert isinstance(meta_prompt, str)
+        assert len(meta_prompt) > 100, "Meta prompt should have substantial content"
+        
+        # Should contain review-related guidance
+        meta_prompt_lower = meta_prompt.lower()
+        assert any(keyword in meta_prompt_lower for keyword in ["review", "code", "analyze", "check"])
+
+
+@pytest.mark.integration 
+@pytest.mark.skipif(not os.getenv("GITHUB_TOKEN"), reason="Requires GITHUB_TOKEN")
+class TestGitHubIntegration:
+    """Test GitHub integration with real API (requires GITHUB_TOKEN)."""
+    
+    def test_pr_review_with_real_api(self, integration_test_model):
+        """Test PR review with real GitHub data and Gemini API."""
+        from src.server import generate_pr_review
+        
+        # Use a small public PR for testing
+        result = generate_pr_review(
+            github_pr_url="https://github.com/octocat/Hello-World/pull/2",  # Classic test PR
+            temperature=0.5,
+            enable_gemini_review=True,
+            text_output=True,
+            model=integration_test_model,
+        )
+        
+        if result:  # Might fail if PR doesn't exist anymore
+            assert isinstance(result, str)
+            assert len(result) > 100
+            # Should mention PR or code review
+            assert any(keyword in result.lower() for keyword in ["pull request", "pr", "changes", "review"])
+
+
+@pytest.mark.integration
+class TestModelDefaultOverride:
+    """Test that we're actually using gemini-1.5-flash in tests."""
+    
+    def test_model_override_works(self, integration_test_model, small_test_context, monkeypatch):
+        """Test that model override actually uses gemini-1.5-flash."""
+        # Temporarily set default to something else
+        monkeypatch.setenv("GEMINI_MODEL", "gemini-2.0-flash")
+        
+        # But explicitly pass gemini-1.5-flash
+        result = send_to_gemini_for_review(
+            context_content=small_test_context,
+            project_path=None,
+            temperature=0.5,
+            model=integration_test_model,  # Should be gemini-1.5-flash
+            return_text=True,
+            include_formatting=False,
+        )
+        
+        assert result is not None
+        # The response should work (gemini-1.5-flash is valid)
+        assert len(result) > 50


### PR DESCRIPTION
- Create hybrid test suite with real API integration tests
- Add tests/integration/ directory with real Gemini API tests
- Configure pytest to skip integration tests by default
- Update README to clarify default models and aliases
- Improve CLI examples to show path is optional (defaults to current directory)
- Fix URL context examples to be more realistic
- Add GitHub Actions workflow for integration tests
- Document testing approach for both unit and integration tests