### PR TITLE
feat: remove deprecated generate_file_context MCP tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2025-01-06
+
+### Removed
+- **BREAKING**: Removed `generate_file_context` from MCP tool registry
+  - The function remains available for internal use and CLI command
+  - This reduces the public MCP tool count from 4 to 3
+  - Use `ask_gemini` MCP tool instead for file-based context with AI response
+- Removed deprecation warning test as the tool is no longer exposed
+
+### Changed
+- Updated documentation to reflect only 3 available MCP tools
+- CLI command `generate-file-context` remains available for debugging purposes
+
 ## [0.4.2] - 2025-01-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ If the MCP tools aren't working:
 | **`generate_ai_code_review`** | Complete AI code review | `project_path`, `model`, `scope` |
 | **`generate_pr_review`** | GitHub PR analysis | `github_pr_url`, `project_path` |
 | **`ask_gemini`** | Generate context and get AI response | `user_instructions`, `file_selections` |
-| **`generate_file_context`** (Deprecated) | Generate context without AI | `file_selections`, `user_instructions` |
 
 <details>
 <summary>📖 Detailed Tool Examples</summary>
@@ -153,22 +152,6 @@ If the MCP tools aren't working:
   arguments: {
     user_instructions: "Explain the security implications of the current authentication approach",
     include_claude_memory: true  // Includes project guidelines
-  }
-}
-```
-
-### File-Based Context Generation (Deprecated)
-```javascript
-// DEPRECATED: Use ask_gemini instead for AI responses
-{
-  tool_name: "generate_file_context",
-  arguments: {
-    file_selections: [
-      { path: "src/main.py" },
-      { path: "src/utils.py", line_ranges: [[10, 50], [100, 150]] }
-    ],
-    project_path: "/path/to/project",
-    user_instructions: "Review for security vulnerabilities"
   }
 }
 ```

--- a/WORKFLOW_DIAGRAMS.md
+++ b/WORKFLOW_DIAGRAMS.md
@@ -6,7 +6,7 @@ ASCII flow diagrams illustrating the data flow for each CLI command and MCP tool
 
 ### Key Implementation Enhancements:
 1. **Ask Gemini Tool**: NEW unified tool that combines file context generation with AI response in one step
-2. **File-Based Context Generation**: Enhanced with `ask_gemini` tool, deprecated `generate_file_context` MCP tool
+2. **File-Based Context Generation**: Enhanced with `ask_gemini` tool, removed deprecated `generate_file_context` MCP tool
 3. **Configuration Discovery**: Added import resolution for CLAUDE.md files (@import syntax)
 4. **Performance**: Async operations and caching mechanisms added but not shown in original diagrams
 5. **Default Behaviors**: 
@@ -14,12 +14,12 @@ ASCII flow diagrams illustrating the data flow for each CLI command and MCP tool
    - `auto_meta_prompt` defaults to `true` for enhanced experience
 6. **Deprecated Features**: 
    - Branch comparison removed, use GitHub PR integration instead
-   - `generate_file_context` MCP tool deprecated, use `ask_gemini` instead
+   - `generate_file_context` MCP tool removed, use `ask_gemini` instead
 
 ### Workflow Accuracy Status:
 - ✅ All main workflows updated to match current implementation (January 2025)
 - ✅ Updated `ask_gemini` as the primary tool for file-based context + AI response
-- ✅ Marked `generate_file_context` MCP tool as deprecated
+- ✅ Removed `generate_file_context` MCP tool (CLI command still available)
 - ✅ Added new ask_gemini Q&A workflows for both CLI and MCP tools
 - ✅ Added missing `raw_context_only` mode to `generate_pr_review` diagram
 - ✅ Added meta-prompt generation step to `generate_pr_review` diagram
@@ -169,7 +169,7 @@ ASCII flow diagrams illustrating the data flow for each CLI command and MCP tool
                        └──────────────────┘
 ```
 
-### MCP Tool: `generate_file_context` (DEPRECATED - Use `ask_gemini` instead)
+### CLI Command: `generate_file_context` (Use `ask_gemini` MCP tool for AI responses)
 
 ```
 ┌─────────────────┐    ┌──────────────────┐    ┌─────────────────┐
@@ -752,11 +752,10 @@ DEFAULT PATTERN (NEW)         INSPECTION PATTERN           NO-FILE PATTERN
 - `ask-gemini-direct` → `src.ask_gemini_cli:direct_main`
 
 ### MCP Tools Dependencies
-**Available MCP Tools (as of v0.4.2):**
+**Available MCP Tools (as of v0.4.3):**
 - `generate_ai_code_review` - Complete AI code review
 - `generate_pr_review` - GitHub PR analysis
 - `ask_gemini` - Generate context and get AI response
-- `generate_file_context` (Deprecated) - Generate context without AI
 
 **Internal Helpers (not exposed as MCP tools):**
 - `generate_code_review_context` - Build review context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ exclude = [
 
 [project]
 name = "gemini-code-review-mcp"
-version = "0.4.2"
+version = "0.4.3"
 description = "MCP server for AI-powered code reviews using Google Gemini with contextual awareness"
 authors = [
     {name = "Nico Bailon", email = "nico604@pm.me"},

--- a/src/server.py
+++ b/src/server.py
@@ -1414,7 +1414,7 @@ async def generate_meta_prompt(
         raise
 
 
-@mcp.tool()
+# Internal function - not exposed as MCP tool (CLI command still available)
 def generate_file_context(
     file_selections: List[Dict[str, Any]],
     project_path: Optional[str] = None,
@@ -1598,7 +1598,6 @@ def get_mcp_tools():
         "generate_ai_code_review",
         "generate_pr_review",
         "ask_gemini",
-        "generate_file_context",  # legacy compatibility
     ]
 
 

--- a/tests/test_mcp_tools_basic.py
+++ b/tests/test_mcp_tools_basic.py
@@ -126,44 +126,6 @@ class TestMCPToolsBasic:
         # Check url_context has default None  
         assert sig.parameters['url_context'].default is None
     
-    def test_generate_file_context_deprecation_warning(self, temp_project_dir):
-        """Test that generate_file_context raises deprecation warning and does not call Gemini."""
-        from src.server import generate_file_context
-        import warnings
-        
-        # Create a test file
-        test_file = os.path.join(temp_project_dir, "test.py")
-        with open(test_file, 'w') as f:
-            f.write("print('test')")
-        
-        file_selections = [{"path": test_file}]
-        
-        # Capture warnings
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            
-            # Mock send_to_gemini_for_review to ensure it's NOT called
-            with patch('src.server.send_to_gemini_for_review') as mock_gemini:
-                # Call the deprecated function
-                result = generate_file_context(
-                    file_selections=file_selections,
-                    project_path=temp_project_dir,
-                    text_output=True
-                )
-                
-                # Verify deprecation warning was raised
-                assert len(w) == 1
-                assert issubclass(w[0].category, DeprecationWarning)
-                assert "generate_file_context" in str(w[0].message)
-                assert "ask_gemini" in str(w[0].message)
-                
-                # Verify it returns context content
-                assert isinstance(result, str)
-                assert "print('test')" in result
-                
-                # Verify Gemini was NOT called
-                mock_gemini.assert_not_called()
-    
     def test_correct_mcp_tools_are_exposed(self):
         """Test that correct MCP tools are exposed."""
         from src.server import get_mcp_tools
@@ -172,8 +134,8 @@ class TestMCPToolsBasic:
         assert "generate_ai_code_review" in tools
         assert "generate_pr_review" in tools
         assert "ask_gemini" in tools
-        assert "generate_file_context" in tools
         # no longer exposed
+        assert "generate_file_context" not in tools
         assert "generate_code_review_context" not in tools
         assert "generate_meta_prompt" not in tools
     


### PR DESCRIPTION
- Remove @mcp.tool() decorator from generate_file_context function
- Update get_mcp_tools() to return only 3 tools
- Remove deprecation warning test
- Update documentation to reflect only 3 available MCP tools
- Keep CLI command generate-file-context for debugging purposes
- Bump version to 0.4.3

BREAKING CHANGE: generate_file_context is no longer available as an MCP tool. Use ask_gemini instead for file-based context with AI responses.