### PR TITLE
Feat/claude-guidelines-opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING**: Project guidelines (CLAUDE.md and cursor rules) are now opt-in by default
+  - `include_claude_memory` parameter now defaults to `False` in all MCP tools and functions
+  - `include_cursor_rules` parameter remains `False` by default (no change)
+  - This change improves performance and gives users explicit control over configuration inclusion
+
+### Added
+- New CLI flag `--include-claude-memory` to opt-in to CLAUDE.md file inclusion
+- Deprecation warnings for `--no-claude-memory` flag (will be removed in a future version)
+
+### Deprecated
+- `--no-claude-memory` CLI flag - use `--include-claude-memory` to opt-in instead
+  - The flag still works but shows a deprecation warning
+  - Will be removed in the next major version
+
 ## [0.4.3] - 2025-01-06
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Transform your git diffs into actionable insights with contextual awareness of y
 
 ## Why Use This?
 
-- **🎯 Context-Aware Reviews**: Automatically includes your CLAUDE.md guidelines and project standards
+- **🎯 Context-Aware Reviews**: Can include your CLAUDE.md guidelines and project standards (opt-in)
 - **📊 Progress Tracking**: Understands your task lists and development phases
 - **🤖 AI Agent Integration**: Seamless MCP integration with Claude Code and Cursor
 - **🔄 Flexible Workflows**: GitHub PR reviews, project analysis, or custom scopes
@@ -33,29 +33,17 @@ Transform your git diffs into actionable insights with contextual awareness of y
 
 ## 🚀 Claude Code Installation
 
-**Option A:** Install the MCP server to Claude Code as user-scoped MCP server:
+**Option A:** Install the MCP server to Claude Code as user-scoped MCP server (recommended):
+```bash
+claude mcp add-json gemini-code-review -s user '{"command":"uvx","args":["gemini-code-review-mcp"],"env":{"GEMINI_API_KEY":"your_key_here","GITHUB_TOKEN":"your_github_token_here"}}'
 ```
-claude mcp add-json gemini-code-review -s user '{"command":"uvx","args":["gemini-code-review-mcp"],"env":{"GEMINI_API_KEY":"your_key_here","GITHUB_TOKEN":"your_key_here"}}'
-```
-(`-s user` installs as user-scoped and will be available to you across all projects on your machine, and will be private to you. Omit `-s user` to install the as locally scoped.)
+(`-s user` installs as user-scoped and will be available to you across all projects on your machine, and will be private to you.)
 
 **Option B:** Install the MCP server to Claude Code as project-scoped MCP server:
+```bash
+claude mcp add-json gemini-code-review -s project '{"command":"uvx","args":["gemini-code-review-mcp"],"env":{"GEMINI_API_KEY":"your_key_here","GITHUB_TOKEN":"your_github_token_here"}}'
 ```
-claude mcp add-json gemini-code-review -s project /path/to/server '{"type":"stdio","command":"npx","args":["gemini-code-review"],"env":{"GEMINI_API_KEY":"your_key_here","GITHUB_TOKEN":"your_key_here"}}'
-```
-
-The command above creates or updates a `.mcp.json` file to the project root with the following structure:
-```
-{
-  "mcpServers": {
-    "gemini-code-review": {
-      "command": "/path/to/server",
-      "args": ["gemini-code-review"],
-      "env": {"GEMINI_API_KEY":"your_key_here","GITHUB_TOKEN":"your_key_here"}
-    }
-  }
-}
-```
+(This creates or updates a `.mcp.json` file in the project root)
 
 Get your Gemini API key:  https://ai.google.dev/gemini-api/docs/api-key
 
@@ -72,9 +60,8 @@ If the MCP tools aren't working:
 3. If API key shows empty, remove and re-add:
    ```bash
    claude mcp remove gemini-code-review
-   claude mcp add-json gemini-code-review -s user '{"type":"stdio","command":"npx","args":["@modelcontextprotocol/server-gemini-code-review"],"env":{"GEMINI_API_KEY":"your_key_here","GITHUB_TOKEN":"your_key_here"}}'
+   claude mcp add-json gemini-code-review -s user '{"command":"uvx","args":["gemini-code-review-mcp"],"env":{"GEMINI_API_KEY":"your_key_here","GITHUB_TOKEN":"your_github_token_here"}}'
    ```
-   (Make sure you replace `/path/to/server` with the path to your server executable)
 4. **Always restart Claude Desktop after any MCP configuration changes**
 
 ## 📋 Available MCP Tools
@@ -85,8 +72,7 @@ If the MCP tools aren't working:
 | **`generate_pr_review`** | GitHub PR analysis | `github_pr_url`, `project_path` |
 | **`ask_gemini`** | Generate context and get AI response | `user_instructions`, `file_selections` |
 
-<details>
-<summary>📖 Detailed Tool Examples</summary>
+📖 Detailed Tool Examples
 
 ### AI Code Review
 ```javascript
@@ -151,12 +137,10 @@ If the MCP tools aren't working:
   tool_name: "ask_gemini",
   arguments: {
     user_instructions: "Explain the security implications of the current authentication approach",
-    include_claude_memory: true  // Includes project guidelines
+    include_claude_memory: true  // Optional - includes project guidelines (off by default)
   }
 }
 ```
-
-</details>
 
 ### Common Workflows
 
@@ -264,16 +248,16 @@ All models support code review, with varying capabilities:
 } }
 ```
 
-### Automatic Configuration Discovery
+### Optional Configuration Discovery
 
-The tool automatically discovers and includes:
-- 📁 **CLAUDE.md** files at project/user/enterprise levels
-- 📝 **Cursor rules** (`.cursorrules`, `.cursor/rules/*.mdc`)
+The tool can discover and include when opted-in:
+- 📁 **CLAUDE.md** files at project/user/enterprise levels (use `include_claude_memory: true`)
+- 📝 **Cursor rules** (`.cursorrules`, `.cursor/rules/*.mdc`) (use `include_cursor_rules: true`)
 - 🔗 **Import syntax** (`@path/to/file.md`) for modular configs
 
 ## ✨ Key Features
 
-- 🤖 **Smart Context** - Automatically includes CLAUDE.md, task lists, and project structure
+- 🤖 **Smart Context** - Includes task lists and project structure, with optional CLAUDE.md/cursor rules
 - 🎯 **Flexible Scopes** - Review PRs, recent changes, or entire projects
 - ⚡ **Model Selection** - Choose between Gemini 2.0 Flash (speed) or 2.5 Pro (depth)
 - 🔄 **GitHub Integration** - Direct PR analysis with full context
@@ -311,6 +295,9 @@ generate-code-review . \
 # With thinking budget (current directory)
 generate-code-review --thinking-budget 20000 --temperature 0.7
 
+# Include project guidelines (CLAUDE.md)
+generate-code-review --include-claude-memory
+
 # With URL context for framework-specific review
 generate-code-review \
   --file-instructions "Review my async implementation against the official docs" \
@@ -339,17 +326,60 @@ generate-meta-prompt --stream
 
 ## 📦 Development
 
+### Installation for Development
+
+If you want to contribute or modify the code, clone the repository:
+
 ```bash
-# Setup
-git clone https://github.com/yourusername/gemini-code-review-mcp
+# Clone the repository
+git clone https://github.com/nicobailon/gemini-code-review-mcp
 cd gemini-code-review-mcp
+
+# Create a virtual environment (recommended)
+python -m venv venv
+source venv/bin/activate  # On Windows: venv\Scripts\activate
+
+# Install in development mode with all dependencies
 pip install -e ".[dev]"
 
-# Testing commands
-python -m pytest tests/    # Run all tests in venv
+# Set up environment variables
+cp .env.example .env
+# Edit .env and add your GEMINI_API_KEY and GITHUB_TOKEN
+```
+
+### Development Workflow
+
+```bash
+# Run the MCP server locally
+python -m src.server
+
+# Test CLI commands
+generate-code-review /path/to/project
+
+# Run tests
+python -m pytest tests/    # Run all tests
+python -m pytest tests/ -v # Verbose output
+
+# Code quality
 make lint                  # Check code style
+make format               # Auto-format code
 make test-cli             # Test CLI commands
 ```
+
+### Installing Development Version in Claude Code
+
+To use your local development version with Claude Code:
+
+```bash
+# Option 1: Use the local Python script directly
+claude mcp add-json gemini-code-review-dev -s user '{"command":"python","args":["-m","src.server"],"cwd":"/path/to/gemini-code-review-mcp","env":{"GEMINI_API_KEY":"your_key_here","GITHUB_TOKEN":"your_github_token_here"}}'
+
+# Option 2: Install your local version with pip and use it
+pip install -e /path/to/gemini-code-review-mcp
+claude mcp add-json gemini-code-review-dev -s user '{"command":"gemini-code-review-mcp","env":{"GEMINI_API_KEY":"your_key_here","GITHUB_TOKEN":"your_github_token_here"}}'
+```
+
+Remember to restart Claude Desktop after adding the development server.
 
 ### Testing Configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ exclude = [
 
 [project]
 name = "gemini-code-review-mcp"
-version = "0.4.3"
+version = "0.4.4"
 description = "MCP server for AI-powered code reviews using Google Gemini with contextual awareness"
 authors = [
     {name = "Nico Bailon", email = "nico604@pm.me"},

--- a/src/async_configuration_discovery.py
+++ b/src/async_configuration_discovery.py
@@ -19,10 +19,7 @@ import platform
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List, Optional, Tuple
 
-try:
-    from .config_types import DEFAULT_INCLUDE_CLAUDE_MEMORY, DEFAULT_INCLUDE_CURSOR_RULES
-except ImportError:
-    from config_types import DEFAULT_INCLUDE_CLAUDE_MEMORY, DEFAULT_INCLUDE_CURSOR_RULES
+from .config_types import DEFAULT_INCLUDE_CLAUDE_MEMORY, DEFAULT_INCLUDE_CURSOR_RULES
 
 logger = logging.getLogger(__name__)
 

--- a/src/async_configuration_discovery.py
+++ b/src/async_configuration_discovery.py
@@ -243,7 +243,7 @@ async def async_discover_modern_cursor_rules(project_path: str) -> List[Dict[str
 
 async def async_discover_all_configurations(
     project_path: str,
-    include_claude_memory: bool = True,
+    include_claude_memory: bool = False,
     include_cursor_rules: bool = False,
     max_workers: int = 10,
 ) -> Dict[str, Any]:
@@ -440,7 +440,7 @@ def _get_enterprise_directories() -> List[str]:
 # Default high-performance discovery function
 def discover_all_configurations(
     project_path: str,
-    include_claude_memory: bool = True,
+    include_claude_memory: bool = False,
     include_cursor_rules: bool = False,
 ) -> Dict[str, Any]:
     """

--- a/src/async_configuration_discovery.py
+++ b/src/async_configuration_discovery.py
@@ -19,6 +19,11 @@ import platform
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List, Optional, Tuple
 
+try:
+    from .config_types import DEFAULT_INCLUDE_CLAUDE_MEMORY, DEFAULT_INCLUDE_CURSOR_RULES
+except ImportError:
+    from config_types import DEFAULT_INCLUDE_CLAUDE_MEMORY, DEFAULT_INCLUDE_CURSOR_RULES
+
 logger = logging.getLogger(__name__)
 
 # Try to import yaml, fallback if not available
@@ -243,8 +248,8 @@ async def async_discover_modern_cursor_rules(project_path: str) -> List[Dict[str
 
 async def async_discover_all_configurations(
     project_path: str,
-    include_claude_memory: bool = False,
-    include_cursor_rules: bool = False,
+    include_claude_memory: bool = DEFAULT_INCLUDE_CLAUDE_MEMORY,
+    include_cursor_rules: bool = DEFAULT_INCLUDE_CURSOR_RULES,
     max_workers: int = 10,
 ) -> Dict[str, Any]:
     """
@@ -252,8 +257,8 @@ async def async_discover_all_configurations(
 
     Args:
         project_path: Project directory to search
-        include_claude_memory: Whether to discover CLAUDE.md files
-        include_cursor_rules: Whether to discover Cursor rules
+        include_claude_memory: Whether to discover CLAUDE.md files (default: False)
+        include_cursor_rules: Whether to discover Cursor rules (default: False)
         max_workers: Maximum concurrent workers for file operations
 
     Returns:
@@ -440,8 +445,8 @@ def _get_enterprise_directories() -> List[str]:
 # Default high-performance discovery function
 def discover_all_configurations(
     project_path: str,
-    include_claude_memory: bool = False,
-    include_cursor_rules: bool = False,
+    include_claude_memory: bool = DEFAULT_INCLUDE_CLAUDE_MEMORY,
+    include_cursor_rules: bool = DEFAULT_INCLUDE_CURSOR_RULES,
 ) -> Dict[str, Any]:
     """
     High-performance configuration discovery with bulletproof fallbacks.
@@ -451,8 +456,8 @@ def discover_all_configurations(
 
     Args:
         project_path: Project directory to search
-        include_claude_memory: Whether to discover CLAUDE.md files
-        include_cursor_rules: Whether to discover Cursor rules
+        include_claude_memory: Whether to discover CLAUDE.md files (default: False)
+        include_cursor_rules: Whether to discover Cursor rules (default: False)
 
     Returns:
         Dictionary containing all discovered configurations with performance stats

--- a/src/cli_generate_file_context.py
+++ b/src/cli_generate_file_context.py
@@ -70,16 +70,20 @@ EXAMPLES:
         "--user-instructions",
         help="Custom instructions to embed in the context"
     )
-    parser.add_argument(
+    
+    # Use mutual exclusion group for claude memory flags
+    claude_memory_group = parser.add_mutually_exclusive_group()
+    claude_memory_group.add_argument(
         "--include-claude-memory",
         action="store_true",
         help="Include CLAUDE.md files in context (optional - off by default)"
     )
-    parser.add_argument(
+    claude_memory_group.add_argument(
         "--no-claude-memory",
         action="store_true",
         help="[DEPRECATED] Use --include-claude-memory instead. This flag will be removed in a future version."
     )
+    
     parser.add_argument(
         "--include-cursor-rules",
         action="store_true",
@@ -116,16 +120,6 @@ def main():
             "--no-claude-memory is deprecated and will be removed in a future version. "
             "Use --include-claude-memory to opt-in to CLAUDE.md inclusion.",
             DeprecationWarning,
-            stacklevel=2
-        )
-    
-    # Check for conflicting flags
-    if args.include_claude_memory and args.no_claude_memory:
-        import warnings
-        warnings.warn(
-            "Both --include-claude-memory and --no-claude-memory specified. "
-            "--include-claude-memory takes precedence.",
-            UserWarning,
             stacklevel=2
         )
     

--- a/src/cli_generate_file_context.py
+++ b/src/cli_generate_file_context.py
@@ -144,7 +144,7 @@ def main():
             file_selections=parsed_selections,
             project_path=args.project_path,
             user_instructions=args.user_instructions,
-            include_claude_memory=args.include_claude_memory if hasattr(args, 'include_claude_memory') else False,
+            include_claude_memory=args.include_claude_memory,
             include_cursor_rules=args.include_cursor_rules,
             auto_meta_prompt=not args.no_auto_meta_prompt,
             temperature=args.temperature,

--- a/src/cli_generate_file_context.py
+++ b/src/cli_generate_file_context.py
@@ -8,7 +8,6 @@ This is a standalone utility for debugging context generation.
 import argparse
 import os
 import sys
-from typing import List, Optional
 
 # Add current directory to path for imports
 sys.path.insert(0, os.path.dirname(__file__))
@@ -16,13 +15,13 @@ sys.path.insert(0, os.path.dirname(__file__))
 try:
     # Try relative imports first (when run as module)
     from .file_context_generator import generate_file_context_data, save_file_context
-    from .file_context_types import FileContextConfig, FileSelection
+    from .file_context_types import FileContextConfig
     from .file_selector import parse_file_selections
 except ImportError:
     try:
         # Fall back to absolute imports for testing or direct execution
         from file_context_generator import generate_file_context_data, save_file_context
-        from file_context_types import FileContextConfig, FileSelection
+        from file_context_types import FileContextConfig
         from file_selector import parse_file_selections
     except ImportError as e:
         print(f"Required dependencies not available: {e}", file=sys.stderr)

--- a/src/cli_main.py
+++ b/src/cli_main.py
@@ -14,6 +14,10 @@ import sys
 import warnings
 from typing import Any, Dict, List, Optional
 
+# Default values
+DEFAULT_INCLUDE_CLAUDE_MEMORY = False
+DEFAULT_INCLUDE_CURSOR_RULES = False
+
 # Import the main generation function from the old module
 try:
     from .generate_code_review_context import generate_code_review_context_main
@@ -241,13 +245,14 @@ def create_argument_parser():
         "--no-gemini", action="store_true", help=argparse.SUPPRESS
     )  # Hidden deprecated option
 
-    # Auto-prompt generation flags
-    parser.add_argument(
+    # Auto-prompt generation flags (mutual exclusion group)
+    auto_prompt_group = parser.add_mutually_exclusive_group()
+    auto_prompt_group.add_argument(
         "--auto-prompt",
         action="store_true",
         help="Generate optimized prompt using Gemini analysis and use it for AI code review",
     )
-    parser.add_argument(
+    auto_prompt_group.add_argument(
         "--generate-prompt-only",
         action="store_true",
         help="Only generate the optimized prompt, do not run code review",
@@ -295,16 +300,19 @@ def create_argument_parser():
     )
 
     # Configuration inclusion parameters
-    parser.add_argument(
+    # Use mutual exclusion group for claude memory flags
+    claude_memory_group = parser.add_mutually_exclusive_group()
+    claude_memory_group.add_argument(
         "--include-claude-memory",
         action="store_true",
         help="Include CLAUDE.md files in context (optional - off by default)",
     )
-    parser.add_argument(
+    claude_memory_group.add_argument(
         "--no-claude-memory",
         action="store_true",
         help="[DEPRECATED] Use --include-claude-memory instead. This flag will be removed in a future version.",
     )
+    
     parser.add_argument(
         "--include-cursor-rules",
         action="store_true",
@@ -351,22 +359,9 @@ def validate_cli_arguments(args: Any):
             stacklevel=2
         )
         
-    # Check for conflicting claude memory flags
-    if args.include_claude_memory and args.no_claude_memory:
-        warnings.warn(
-            "Both --include-claude-memory and --no-claude-memory specified. "
-            "--include-claude-memory takes precedence.",
-            UserWarning,
-            stacklevel=2
-        )
+    # Note: argparse mutual exclusion group handles conflicting flags automatically
 
-    # Check for mutually exclusive auto-prompt flags
-    if args.auto_prompt and args.generate_prompt_only:
-        raise ValueError(
-            "--auto-prompt and --generate-prompt-only are mutually exclusive. "
-            "Use --auto-prompt to generate a prompt and run code review, or "
-            "--generate-prompt-only to only generate the prompt."
-        )
+    # No need to check for mutually exclusive auto-prompt flags - argparse handles it
 
     # Check for conflicts with context-only
     if args.generate_prompt_only and args.context_only:
@@ -411,7 +406,6 @@ def execute_auto_prompt_workflow(
             raise Exception("Auto-prompt generation failed")
 
         generated_prompt = prompt_result["generated_prompt"]
-        # context_analyzed = prompt_result["context_analyzed"]  # Not used currently
 
         # Format output for prompt-only mode
         if generate_prompt_only:
@@ -452,11 +446,8 @@ def execute_auto_prompt_workflow(
                 auto_prompt_content=generated_prompt,  # Pass the meta-prompt to embed in context
                 **context_kwargs,
             )
-            # context_file = context_result[0]  # Not used currently
 
             # Run AI review with custom prompt
-            # Convert to absolute path if needed
-            # absolute_context_file = os.path.abspath(context_file)  # Not used currently
             # Note: AI code review generation has been disabled to avoid circular imports
             # The auto-prompt workflow now only generates context + meta prompt
             # AI review should be handled separately via the MCP server tools
@@ -659,14 +650,14 @@ Working examples:
                 workflow_kwargs = {
                     "phase": args.phase,
                     "output": args.output,
-                    "phase_number": getattr(args, "phase_number"),
-                    "task_number": getattr(args, "task_number"),
-                    "task_list": getattr(args, "task_list"),
-                    "default_prompt": getattr(args, "default_prompt"),
-                    "compare_branch": getattr(args, "compare_branch"),
-                    "target_branch": getattr(args, "target_branch"),
-                    "github_pr_url": getattr(args, "github_pr_url"),
-                    "include_claude_memory": args.include_claude_memory if hasattr(args, 'include_claude_memory') else False,
+                    "phase_number": args.phase_number,
+                    "task_number": args.task_number,
+                    "task_list": args.task_list,
+                    "default_prompt": args.default_prompt,
+                    "compare_branch": args.compare_branch,
+                    "target_branch": args.target_branch,
+                    "github_pr_url": args.github_pr_url,
+                    "include_claude_memory": args.include_claude_memory,
                     "include_cursor_rules": args.include_cursor_rules,
                 }
 
@@ -714,7 +705,7 @@ Working examples:
                     file_selections=file_selections,
                     project_path=args.project_path,
                     user_instructions=args.file_instructions,
-                    include_claude_memory=args.include_claude_memory if hasattr(args, 'include_claude_memory') else False,
+                    include_claude_memory=args.include_claude_memory,
                     include_cursor_rules=args.include_cursor_rules,
                     auto_meta_prompt=args.auto_prompt,
                     temperature=temperature,
@@ -771,18 +762,18 @@ Working examples:
             output=args.output,
             enable_gemini_review=enable_gemini,
             scope=args.scope,
-            phase_number=getattr(args, "phase_number"),
-            task_number=getattr(args, "task_number"),
+            phase_number=args.phase_number,
+            task_number=args.task_number,
             temperature=temperature,
-            task_list=getattr(args, "task_list"),
-            default_prompt=getattr(args, "default_prompt"),
-            compare_branch=getattr(args, "compare_branch"),
-            target_branch=getattr(args, "target_branch"),
-            github_pr_url=getattr(args, "github_pr_url"),
-            include_claude_memory=args.include_claude_memory if hasattr(args, 'include_claude_memory') else False,
+            task_list=args.task_list,
+            default_prompt=args.default_prompt,
+            compare_branch=args.compare_branch,
+            target_branch=args.target_branch,
+            github_pr_url=args.github_pr_url,
+            include_claude_memory=args.include_claude_memory,
             include_cursor_rules=args.include_cursor_rules,
-            thinking_budget=getattr(args, "thinking_budget", None),
-            url_context=getattr(args, "url_context", None),
+            thinking_budget=args.thinking_budget,
+            url_context=args.url_context,
         )
 
         print("\n🎉 Code review process completed!")

--- a/src/cli_main.py
+++ b/src/cli_main.py
@@ -14,10 +14,6 @@ import sys
 import warnings
 from typing import Any, Dict, List, Optional
 
-# Default values
-DEFAULT_INCLUDE_CLAUDE_MEMORY = False
-DEFAULT_INCLUDE_CURSOR_RULES = False
-
 # Import the main generation function from the old module
 try:
     from .generate_code_review_context import generate_code_review_context_main

--- a/src/config_types.py
+++ b/src/config_types.py
@@ -8,6 +8,10 @@ This module defines shared configuration types used across the codebase.
 from dataclasses import dataclass
 from typing import Optional, Union, List
 
+# Central configuration defaults
+DEFAULT_INCLUDE_CLAUDE_MEMORY = False
+DEFAULT_INCLUDE_CURSOR_RULES = False
+
 
 @dataclass
 class CodeReviewConfig:
@@ -26,8 +30,8 @@ class CodeReviewConfig:
     compare_branch: Optional[str] = None
     target_branch: Optional[str] = None
     github_pr_url: Optional[str] = None
-    include_claude_memory: bool = False
-    include_cursor_rules: bool = False
+    include_claude_memory: bool = DEFAULT_INCLUDE_CLAUDE_MEMORY
+    include_cursor_rules: bool = DEFAULT_INCLUDE_CURSOR_RULES
     raw_context_only: bool = False
     auto_prompt_content: Optional[str] = None
     thinking_budget: Optional[int] = None

--- a/src/config_types.py
+++ b/src/config_types.py
@@ -26,7 +26,7 @@ class CodeReviewConfig:
     compare_branch: Optional[str] = None
     target_branch: Optional[str] = None
     github_pr_url: Optional[str] = None
-    include_claude_memory: bool = True
+    include_claude_memory: bool = False
     include_cursor_rules: bool = False
     raw_context_only: bool = False
     auto_prompt_content: Optional[str] = None

--- a/src/config_types.py
+++ b/src/config_types.py
@@ -12,6 +12,12 @@ from typing import Optional, Union, List
 DEFAULT_INCLUDE_CLAUDE_MEMORY = False
 DEFAULT_INCLUDE_CURSOR_RULES = False
 
+__all__ = (
+    "CodeReviewConfig",
+    "DEFAULT_INCLUDE_CLAUDE_MEMORY",
+    "DEFAULT_INCLUDE_CURSOR_RULES",
+)
+
 
 @dataclass
 class CodeReviewConfig:

--- a/src/context_builder.py
+++ b/src/context_builder.py
@@ -12,10 +12,7 @@ import logging
 import os
 from typing import Any, Dict, List, Optional, TypedDict
 
-try:
-    from .config_types import DEFAULT_INCLUDE_CLAUDE_MEMORY, DEFAULT_INCLUDE_CURSOR_RULES
-except ImportError:
-    from config_types import DEFAULT_INCLUDE_CLAUDE_MEMORY, DEFAULT_INCLUDE_CURSOR_RULES
+from .config_types import DEFAULT_INCLUDE_CLAUDE_MEMORY, DEFAULT_INCLUDE_CURSOR_RULES
 
 logger = logging.getLogger(__name__)
 

--- a/src/context_builder.py
+++ b/src/context_builder.py
@@ -357,7 +357,7 @@ def discover_project_configurations_with_fallback(project_path: str) -> Dict[str
 
 def discover_project_configurations_with_flags(
     project_path: str,
-    include_claude_memory: bool = True,
+    include_claude_memory: bool = False,
     include_cursor_rules: bool = False,
 ) -> DiscoveredConfigurations:
     """

--- a/src/cursor_rules_parser.py
+++ b/src/cursor_rules_parser.py
@@ -457,7 +457,7 @@ def classify_rule_type(metadata: Dict[str, Any]) -> str:
     # Check for explicit type override
     explicit_type = metadata.get("type")
     if explicit_type in ["auto", "agent", "manual"]:
-        return explicit_type
+        return str(explicit_type)
 
     # Default classification based on alwaysApply
     always_apply = metadata.get("alwaysApply", False)

--- a/src/file_context_types.py
+++ b/src/file_context_types.py
@@ -33,7 +33,7 @@ class FileContextConfig:
     file_selections: List[FileSelection]
     project_path: Optional[str] = None
     user_instructions: Optional[str] = None
-    include_claude_memory: bool = True
+    include_claude_memory: bool = False
     include_cursor_rules: bool = False
     auto_meta_prompt: bool = True
     temperature: float = 0.5

--- a/src/generate_code_review_context.py
+++ b/src/generate_code_review_context.py
@@ -146,7 +146,7 @@ def generate_code_review_context_main(
     compare_branch: Optional[str] = None,
     target_branch: Optional[str] = None,
     github_pr_url: Optional[str] = None,
-    include_claude_memory: bool = True,
+    include_claude_memory: bool = False,
     include_cursor_rules: bool = False,
     raw_context_only: bool = False,
     auto_prompt_content: Optional[str] = None,

--- a/src/meta_prompt_generator.py
+++ b/src/meta_prompt_generator.py
@@ -101,7 +101,7 @@ def _get_generate_meta_prompt() -> Any:
                         scope=scope,
                         enable_gemini_review=False,
                         raw_context_only=True,
-                        include_claude_memory=True,
+                        include_claude_memory=False,
                         include_cursor_rules=False,
                     )
 

--- a/src/meta_prompt_generator.py
+++ b/src/meta_prompt_generator.py
@@ -11,7 +11,7 @@ import asyncio
 import os
 import sys
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 
 def validate_prompt(prompt: Dict[str, Any]) -> Dict[str, Any]:
@@ -86,7 +86,7 @@ def _get_generate_meta_prompt() -> Any:
 
                 async def generate_meta_prompt(
                     *args: Any, **kwargs: Any
-                ) -> Dict[str, Any]:
+                ) -> Union[Dict[str, Any], str]:
                     """Generate meta-prompt directly without server dependency."""
                     # Get project context first
                     project_path: Optional[str] = kwargs.get("project_path")

--- a/src/server.py
+++ b/src/server.py
@@ -254,7 +254,9 @@ def generate_context_in_memory(
         if include_claude_memory or include_cursor_rules:
             try:
                 config_data = discover_project_configurations_with_fallback(
-                    project_path
+                    project_path,
+                    include_claude_memory=include_claude_memory,
+                    include_cursor_rules=include_cursor_rules
                 )
 
                 if include_claude_memory and config_data.get("claude_memory_files"):
@@ -1248,8 +1250,8 @@ async def generate_meta_prompt(
                 scope=scope,
                 enable_gemini_review=False,
                 raw_context_only=True,
-                include_claude_memory=include_claude_memory,
-                include_cursor_rules=include_cursor_rules,
+                include_claude_memory=False,  # Use default for meta prompt generation
+                include_cursor_rules=False,   # Use default for meta prompt generation
             )
 
             # Generate context data (this gathers all the data but doesn't save anything)

--- a/src/server.py
+++ b/src/server.py
@@ -124,7 +124,7 @@ generate_context = generate_review_context
 def generate_context_in_memory(
     github_pr_url: Optional[str] = None,
     project_path: Optional[str] = None,
-    include_claude_memory: bool = True,
+    include_claude_memory: bool = False,
     include_cursor_rules: bool = False,
     auto_prompt_content: Optional[str] = None,
     temperature: float = 0.5,
@@ -138,8 +138,8 @@ def generate_context_in_memory(
     Args:
         github_pr_url: GitHub PR URL for analysis
         project_path: Project directory path
-        include_claude_memory: Include CLAUDE.md files in context
-        include_cursor_rules: Include Cursor rules files in context
+        include_claude_memory: Include CLAUDE.md files in context (optional - off by default)
+        include_cursor_rules: Include Cursor rules files in context (optional - off by default)
         auto_prompt_content: Generated meta-prompt content to embed
         temperature: AI temperature setting
 
@@ -313,7 +313,7 @@ async def generate_pr_review(
     project_path: Optional[str] = None,
     temperature: float = 0.5,
     enable_gemini_review: bool = True,
-    include_claude_memory: bool = True,
+    include_claude_memory: bool = False,
     include_cursor_rules: bool = False,
     auto_meta_prompt: bool = True,
     use_templated_instructions: bool = False,
@@ -330,8 +330,8 @@ async def generate_pr_review(
         project_path: Optional local project path for context (default: current directory)
         temperature: Temperature for AI model (default: 0.5, range: 0.0-2.0)
         enable_gemini_review: Enable Gemini AI code review generation (default: true)
-        include_claude_memory: Include CLAUDE.md files in context (default: true)
-        include_cursor_rules: Include Cursor rules files in context (default: false)
+        include_claude_memory: Include CLAUDE.md files in context (optional - off by default)
+        include_cursor_rules: Include Cursor rules files in context (optional - off by default)
         auto_meta_prompt: Automatically generate and embed meta prompt in user_instructions (default: true)
         use_templated_instructions: Use templated backup instructions instead of generated meta prompt (default: false)
         create_context_file: Save context to file and return context content (default: false)
@@ -581,7 +581,7 @@ def generate_code_review_context(
     output_path: Optional[str] = None,
     enable_gemini_review: bool = False,
     temperature: float = 0.5,
-    include_claude_memory: bool = True,
+    include_claude_memory: bool = False,
     include_cursor_rules: bool = False,
     raw_context_only: bool = False,
     text_output: bool = True,
@@ -600,8 +600,8 @@ def generate_code_review_context(
         output_path: Custom output file path. If not provided, uses default timestamped path
         enable_gemini_review: Enable Gemini AI code review generation (default: true)
         temperature: Temperature for AI model (default: 0.5, range: 0.0-2.0)
-        include_claude_memory: Include CLAUDE.md files in context (default: true)
-        include_cursor_rules: Include Cursor rules files in context (default: false)
+        include_claude_memory: Include CLAUDE.md files in context (optional - off by default)
+        include_cursor_rules: Include Cursor rules files in context (optional - off by default)
         raw_context_only: Exclude default AI review instructions (default: false)
         text_output: Return context directly as text (default: true - for AI agent chaining)
         auto_meta_prompt: Automatically generate and embed meta prompt in user_instructions (default: true)
@@ -781,7 +781,7 @@ def generate_ai_code_review(
     custom_prompt: Optional[str] = None,
     text_output: bool = True,
     auto_meta_prompt: bool = True,
-    include_claude_memory: bool = True,
+    include_claude_memory: bool = False,
     include_cursor_rules: bool = False,
     thinking_budget: Optional[int] = None,
     url_context: Optional[Union[str, List[str]]] = None,
@@ -801,8 +801,8 @@ def generate_ai_code_review(
         custom_prompt: Optional custom AI prompt to override default instructions
         text_output: Return review directly as text (default: true - for AI agent chaining)
         auto_meta_prompt: Automatically generate and embed meta prompt (default: true)
-        include_claude_memory: Include CLAUDE.md files in context (default: true)
-        include_cursor_rules: Include Cursor rules files in context (default: false)
+        include_claude_memory: Include CLAUDE.md files in context (optional - off by default)
+        include_cursor_rules: Include Cursor rules files in context (optional - off by default)
         thinking_budget: Optional token budget for thinking mode (if supported by model)
         url_context: Optional URL(s) to include in context - can be string or list of strings
 
@@ -1248,8 +1248,8 @@ async def generate_meta_prompt(
                 scope=scope,
                 enable_gemini_review=False,
                 raw_context_only=True,
-                include_claude_memory=True,
-                include_cursor_rules=False,
+                include_claude_memory=include_claude_memory,
+                include_cursor_rules=include_cursor_rules,
             )
 
             # Generate context data (this gathers all the data but doesn't save anything)
@@ -1419,7 +1419,7 @@ def generate_file_context(
     file_selections: List[Dict[str, Any]],
     project_path: Optional[str] = None,
     user_instructions: Optional[str] = None,
-    include_claude_memory: bool = True,
+    include_claude_memory: bool = False,
     include_cursor_rules: bool = False,
     auto_meta_prompt: bool = True,
     temperature: float = 0.5,
@@ -1439,8 +1439,8 @@ def generate_file_context(
             - include_full: bool (default True) - Include full file if no ranges specified
         project_path: Optional project root for relative paths and config discovery
         user_instructions: Custom instructions for the context
-        include_claude_memory: Include CLAUDE.md files in context
-        include_cursor_rules: Include Cursor rules files in context  
+        include_claude_memory: Include CLAUDE.md files in context (optional - off by default)
+        include_cursor_rules: Include Cursor rules files in context (optional - off by default)  
         auto_meta_prompt: Generate context-aware meta-prompt
         temperature: AI temperature for meta-prompt generation
         text_output: Return content directly (True) or save to file (False)
@@ -1511,7 +1511,7 @@ def ask_gemini(
     user_instructions: Optional[str] = None,
     file_selections: Optional[List[Dict[str, Any]]] = None,
     project_path: Optional[str] = None,
-    include_claude_memory: bool = True,
+    include_claude_memory: bool = False,
     include_cursor_rules: bool = False,
     auto_meta_prompt: bool = True,
     temperature: float = 0.5,
@@ -1528,8 +1528,8 @@ def ask_gemini(
         user_instructions: The primary query or instructions for Gemini.
         file_selections: Optional list of files/line ranges to include in the context.
         project_path: Optional project root for relative paths.
-        include_claude_memory: Include CLAUDE.md files in context.
-        include_cursor_rules: Include Cursor rules files in context.
+        include_claude_memory: Include CLAUDE.md files in context (optional - off by default).
+        include_cursor_rules: Include Cursor rules files in context (optional - off by default).
         auto_meta_prompt: If no user_instructions, generate a meta-prompt.
         temperature: AI temperature for generation.
         model: Specific Gemini model to use.

--- a/tests/test_ask_gemini.py
+++ b/tests/test_ask_gemini.py
@@ -7,7 +7,7 @@ with direct Gemini API calls.
 """
 
 import pytest
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock
 import sys
 import os
 
@@ -95,8 +95,8 @@ class TestAskGeminiTool:
         )
         
         with patch("src.server.FileContextConfig", return_value=mock_config) as mock_config_class:
-            with patch("src.server.generate_file_context_data", return_value=mock_result) as mock_generate:
-                with patch("src.server.send_to_gemini_for_review", return_value="AI analysis of files") as mock_gemini:
+            with patch("src.server.generate_file_context_data", return_value=mock_result):
+                with patch("src.server.send_to_gemini_for_review", return_value="AI analysis of files"):
                     # Call the function
                     result = ask_gemini(
                         user_instructions="Analyze these files",

--- a/tests/test_ask_gemini.py
+++ b/tests/test_ask_gemini.py
@@ -55,7 +55,7 @@ class TestAskGeminiTool:
                     config_call = mock_config_class.call_args
                     assert config_call.kwargs["file_selections"] == []
                     assert config_call.kwargs["user_instructions"] == "Review this code for security issues"
-                    assert config_call.kwargs["include_claude_memory"] is True
+                    assert config_call.kwargs["include_claude_memory"] is False
                     assert config_call.kwargs["temperature"] == 0.5
                     
                     # Verify generate_file_context_data was called

--- a/tests/test_cli_generate_file_context.py
+++ b/tests/test_cli_generate_file_context.py
@@ -87,8 +87,8 @@ class TestGenerateFileContextCLI:
         
         test_args = [
             "generate-file-context",
-            "-f", f"{test_file}:2-4",
-            "--no-claude-memory"
+            "-f", f"{test_file}:2-4"
+            # Remove deprecated flag - CLAUDE.md inclusion is opt-in by default
         ]
         
         with patch.object(sys, 'argv', test_args):

--- a/tests/test_cli_generate_file_context.py
+++ b/tests/test_cli_generate_file_context.py
@@ -6,9 +6,8 @@ Tests for the generate-file-context CLI command.
 import pytest
 import os
 import sys
-import tempfile
+from pathlib import Path
 from unittest.mock import patch, MagicMock
-import subprocess
 
 # Import from the installed package
 try:
@@ -22,7 +21,7 @@ except ImportError:
 class TestGenerateFileContextCLI:
     """Test suite for the generate-file-context CLI command."""
     
-    def test_parser_creation(self):
+    def test_parser_creation(self) -> None:
         """Test that the argument parser is created correctly."""
         parser = create_parser()
         
@@ -34,7 +33,7 @@ class TestGenerateFileContextCLI:
         assert args.file_selections == ["test.py"]
         assert args.output_path == "output.md"
     
-    def test_cli_with_single_file(self, tmp_path):
+    def test_cli_with_single_file(self, tmp_path: Path) -> None:
         """Test CLI with a single file selection."""
         # Create test file
         test_file = tmp_path / "test.py"
@@ -65,7 +64,7 @@ class TestGenerateFileContextCLI:
         assert "def hello():" in content
         assert "print('Hello')" in content
     
-    def test_cli_with_line_ranges(self, tmp_path):
+    def test_cli_with_line_ranges(self, tmp_path: Path) -> None:
         """Test CLI with line range selection."""
         # Create test file with multiple lines
         test_file = tmp_path / "test.py"
@@ -107,7 +106,7 @@ class TestGenerateFileContextCLI:
                 assert file_selections[0]["path"] == str(test_file)
                 assert file_selections[0]["line_ranges"] == [(2, 4)]
     
-    def test_cli_error_invalid_file_selection(self):
+    def test_cli_error_invalid_file_selection(self) -> None:
         """Test CLI with invalid file selection format."""
         test_args = [
             "generate-file-context",
@@ -122,7 +121,7 @@ class TestGenerateFileContextCLI:
                 # Should exit with error code
                 assert exc_info.value.code == 1
     
-    def test_cli_with_custom_instructions(self, tmp_path):
+    def test_cli_with_custom_instructions(self, tmp_path: Path) -> None:
         """Test CLI with custom user instructions."""
         test_file = tmp_path / "test.py"
         test_file.write_text("# Test file")
@@ -154,7 +153,7 @@ class TestGenerateFileContextCLI:
                 config_call = mock_config_class.call_args
                 assert config_call.kwargs['user_instructions'] == "Focus on error handling"
     
-    def test_cli_stdout_output(self, tmp_path, capsys):
+    def test_cli_stdout_output(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         """Test CLI output to stdout when no output file specified."""
         test_file = tmp_path / "test.py"
         test_file.write_text("print('test')")

--- a/tests/test_context_builder.py
+++ b/tests/test_context_builder.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Tests for context_builder module to ensure proper flag handling.
+"""
+
+import os
+import tempfile
+from unittest.mock import patch
+import pytest
+
+from src.context_builder import (
+    discover_project_configurations_with_flags,
+    generate_enhanced_review_context,
+    discover_project_configurations,
+)
+
+
+def test_discover_configurations_respects_default_flags():
+    """Test that discovery respects the default False flags for CLAUDE.md and cursor rules."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create CLAUDE.md and .cursorrules files
+        claude_file = os.path.join(tmpdir, "CLAUDE.md")
+        with open(claude_file, "w") as f:
+            f.write("# Project guidelines\nTest content")
+        
+        cursor_file = os.path.join(tmpdir, ".cursorrules")
+        with open(cursor_file, "w") as f:
+            f.write("# Cursor rules\nTest rules")
+        
+        # Test with defaults (should not include files)
+        result = discover_project_configurations(tmpdir)
+        assert len(result["claude_memory_files"]) == 0
+        assert len(result["cursor_rules"]) == 0
+        
+        # Test with explicit False (same behavior)
+        result = discover_project_configurations(tmpdir, include_claude_memory=False, include_cursor_rules=False)
+        assert len(result["claude_memory_files"]) == 0
+        assert len(result["cursor_rules"]) == 0
+        
+        # Test with explicit True (should include files)
+        result = discover_project_configurations(tmpdir, include_claude_memory=True, include_cursor_rules=True)
+        assert len(result["claude_memory_files"]) > 0
+        assert len(result["cursor_rules"]) > 0
+
+
+def test_discover_configurations_with_flags_respects_defaults():
+    """Test that discover_project_configurations_with_flags respects default False flags."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create CLAUDE.md file
+        claude_file = os.path.join(tmpdir, "CLAUDE.md")
+        with open(claude_file, "w") as f:
+            f.write("# Test content")
+        
+        # Test with defaults
+        result = discover_project_configurations_with_flags(tmpdir)
+        assert len(result["claude_memory_files"]) == 0
+        assert len(result["cursor_rules"]) == 0
+        
+        # Test with explicit True
+        result = discover_project_configurations_with_flags(
+            tmpdir, 
+            include_claude_memory=True,
+            include_cursor_rules=True
+        )
+        assert len(result["claude_memory_files"]) > 0
+
+
+def test_generate_enhanced_review_context_respects_flags():
+    """Test that generate_enhanced_review_context respects the include flags."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create test files
+        claude_file = os.path.join(tmpdir, "CLAUDE.md")
+        with open(claude_file, "w") as f:
+            f.write("# Claude memory content")
+        
+        # Mock git_utils to avoid git dependency
+        with patch("src.git_utils.get_changed_files") as mock_git:
+            mock_git.return_value = []
+            
+            # Test with defaults (should not include configuration)
+            context = generate_enhanced_review_context(tmpdir)
+            assert len(context.get("claude_memory_files", [])) == 0
+            assert context.get("configuration_content", "") == ""
+            
+            # Test with explicit True
+            context = generate_enhanced_review_context(
+                tmpdir,
+                include_claude_memory=True
+            )
+            assert len(context.get("claude_memory_files", [])) > 0
+            assert "Claude Memory Configuration" in context.get("configuration_content", "")
+
+
+def test_cache_respects_different_flag_combinations():
+    """Test that the cache correctly handles different flag combinations."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create test files
+        claude_file = os.path.join(tmpdir, "CLAUDE.md")
+        with open(claude_file, "w") as f:
+            f.write("# Claude content")
+        
+        cursor_file = os.path.join(tmpdir, ".cursorrules")
+        with open(cursor_file, "w") as f:
+            f.write("# Cursor rules")
+        
+        # Test different flag combinations
+        result1 = discover_project_configurations(tmpdir, False, False)
+        assert len(result1["claude_memory_files"]) == 0
+        assert len(result1["cursor_rules"]) == 0
+        
+        result2 = discover_project_configurations(tmpdir, True, False)
+        assert len(result2["claude_memory_files"]) > 0
+        assert len(result2["cursor_rules"]) == 0
+        
+        result3 = discover_project_configurations(tmpdir, False, True)
+        assert len(result3["claude_memory_files"]) == 0
+        assert len(result3["cursor_rules"]) > 0
+        
+        result4 = discover_project_configurations(tmpdir, True, True)
+        assert len(result4["claude_memory_files"]) > 0
+        assert len(result4["cursor_rules"]) > 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_context_builder.py
+++ b/tests/test_context_builder.py
@@ -5,7 +5,7 @@ Tests for context_builder module to ensure proper flag handling.
 
 import os
 import tempfile
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 import pytest
 
 from src.context_builder import (
@@ -15,7 +15,7 @@ from src.context_builder import (
 )
 
 
-def test_discover_configurations_respects_default_flags():
+def test_discover_configurations_respects_default_flags() -> None:
     """Test that discovery respects the default False flags for CLAUDE.md and cursor rules."""
     with tempfile.TemporaryDirectory() as tmpdir:
         # Create CLAUDE.md and .cursorrules files
@@ -43,7 +43,7 @@ def test_discover_configurations_respects_default_flags():
         assert len(result["cursor_rules"]) > 0
 
 
-def test_discover_configurations_with_flags_respects_defaults():
+def test_discover_configurations_with_flags_respects_defaults() -> None:
     """Test that discover_project_configurations_with_flags respects default False flags."""
     with tempfile.TemporaryDirectory() as tmpdir:
         # Create CLAUDE.md file
@@ -65,7 +65,7 @@ def test_discover_configurations_with_flags_respects_defaults():
         assert len(result["claude_memory_files"]) > 0
 
 
-def test_generate_enhanced_review_context_respects_flags():
+def test_generate_enhanced_review_context_respects_flags() -> None:
     """Test that generate_enhanced_review_context respects the include flags."""
     with tempfile.TemporaryDirectory() as tmpdir:
         # Create test files
@@ -75,6 +75,7 @@ def test_generate_enhanced_review_context_respects_flags():
         
         # Mock git_utils to avoid git dependency
         with patch("src.git_utils.get_changed_files") as mock_git:
+            mock_git: MagicMock
             mock_git.return_value = []
             
             # Test with defaults (should not include configuration)
@@ -91,7 +92,7 @@ def test_generate_enhanced_review_context_respects_flags():
             assert "Claude Memory Configuration" in context.get("configuration_content", "")
 
 
-def test_cache_respects_different_flag_combinations():
+def test_cache_respects_different_flag_combinations() -> None:
     """Test that the cache correctly handles different flag combinations."""
     with tempfile.TemporaryDirectory() as tmpdir:
         # Create test files

--- a/tests/test_critical.py
+++ b/tests/test_critical.py
@@ -28,17 +28,17 @@ class TestCoreImports:
 
     def test_generate_code_review_context_imports(self):
         """Test generate_code_review_context module imports"""
-        import generate_code_review_context
+        from src import generate_code_review_context
 
         assert hasattr(generate_code_review_context, "main")
         # load_model_config is now in model_config_manager
-        from model_config_manager import load_model_config
+        from src.model_config_manager import load_model_config
 
         assert callable(load_model_config)
 
     def test_ai_code_review_imports(self):
         """Test ai_code_review functionality is available in server"""
-        from server import generate_ai_code_review
+        from src.server import generate_ai_code_review
         
         # The function might be wrapped in an MCP FunctionTool or be a plain function
         # depending on how the module is loaded

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -83,7 +83,7 @@ def test_cli_help_functions():
 
 def test_mcp_server_startup():
     """Test that MCP server can be imported and basic setup works"""
-    from server import main as server_main
+    from src.server import main as server_main
 
     # Should be able to import the main function
     assert callable(server_main)


### PR DESCRIPTION
- Add test_context_builder.py with tests verifying opt-in behavior
- Test that discover_project_configurations respects default False flags
- Test that discover_project_configurations_with_flags respects defaults
- Test that generate_enhanced_review_context respects include flags
- Test cache behavior with different flag combinations
- Ensures configuration discovery honors the opt-in principle

All tests pass, confirming the context_builder correctly implements
the opt-in behavior for CLAUDE.md and cursor rules discovery.